### PR TITLE
Apple silicon

### DIFF
--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -1,6 +1,6 @@
-FROM php:5.6-fpm-alpine
+FROM arm64v8/php:5.6-fpm-alpine
 
-ENV COMPOSER_VERSION 1.9.1
+ENV COMPOSER_VERSION 2.0.12
 ENV WP_CLI_VERSION 2.4.0
 
 RUN apk add --no-cache --virtual .build-deps \

--- a/5.6/xdebug/Dockerfile
+++ b/5.6/xdebug/Dockerfile
@@ -1,4 +1,4 @@
-FROM pilothouseapp/php:5.6-dev
+FROM pilothouse_php56:latest
 
 RUN apk add --no-cache --virtual .build-deps \
 	autoconf g++ make \

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -1,6 +1,6 @@
-FROM php:7.0-fpm-alpine
+FROM arm64v8/php:7.0-fpm-alpine
 
-ENV COMPOSER_VERSION 1.9.1
+ENV COMPOSER_VERSION 2.0.12
 ENV WP_CLI_VERSION 2.4.0
 
 RUN apk add --no-cache --virtual .build-deps \

--- a/7.0/xdebug/Dockerfile
+++ b/7.0/xdebug/Dockerfile
@@ -1,6 +1,6 @@
-FROM pilothouseapp/php:7.0-dev
+FROM pilothouse_php70:latest
 
 RUN apk add --no-cache --virtual .build-deps \
 	autoconf g++ make \
-	&& pecl install xdebug-2.9.0 && docker-php-ext-enable xdebug \
+	&& pecl install xdebug-3.0.3 && docker-php-ext-enable xdebug \
 	&& apk del .build-deps

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -1,6 +1,6 @@
 FROM php:7.1-fpm-alpine
 
-ENV COMPOSER_VERSION 1.9.1
+ENV COMPOSER_VERSION 2.0.12
 ENV WP_CLI_VERSION 2.4.0
 
 RUN apk add --no-cache --virtual .build-deps \

--- a/7.1/xdebug/Dockerfile
+++ b/7.1/xdebug/Dockerfile
@@ -1,6 +1,6 @@
-FROM pilothouseapp/php:7.1-dev
+FROM pilothouse_php71:latest
 
 RUN apk add --no-cache --virtual .build-deps \
 	autoconf g++ make \
-	&& pecl install xdebug-2.9.1 && docker-php-ext-enable xdebug \
+	&& pecl install xdebug-3.0.3 && docker-php-ext-enable xdebug \
 	&& apk del .build-deps

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -1,6 +1,6 @@
-FROM php:7.2-fpm-alpine
+FROM arm64v8/php:7.2-fpm-alpine
 
-ENV COMPOSER_VERSION 1.9.1
+ENV COMPOSER_VERSION 2.0.12
 ENV WP_CLI_VERSION 2.4.0
 
 RUN apk add --no-cache --virtual .build-deps \

--- a/7.2/xdebug/Dockerfile
+++ b/7.2/xdebug/Dockerfile
@@ -1,6 +1,6 @@
-FROM pilothouseapp/php:7.2-dev
+FROM pilothouse_php72:latest
 
 RUN apk add --no-cache --virtual .build-deps \
 	autoconf g++ make \
-	&& pecl install xdebug-2.9.1 && docker-php-ext-enable xdebug \
+	&& pecl install xdebug-3.0.3 && docker-php-ext-enable xdebug \
 	&& apk del .build-deps

--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -1,6 +1,6 @@
-FROM php:7.3-fpm-alpine
+FROM arm64v8/php:7.3-fpm-alpine
 
-ENV COMPOSER_VERSION 1.9.1
+ENV COMPOSER_VERSION 2.0.12
 ENV WP_CLI_VERSION 2.4.0
 
 RUN apk add --no-cache --virtual .build-deps \

--- a/7.3/xdebug/Dockerfile
+++ b/7.3/xdebug/Dockerfile
@@ -1,6 +1,6 @@
-FROM pilothouseapp/php:7.3-dev
+FROM pilothouse_php73:latest
 
 RUN apk add --no-cache --virtual .build-deps \
 	autoconf g++ make \
-	&& pecl install xdebug-2.9.1 && docker-php-ext-enable xdebug \
+	&& pecl install xdebug-3.0.3 && docker-php-ext-enable xdebug \
 	&& apk del .build-deps

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -1,6 +1,6 @@
-FROM php:7.4-fpm-alpine
+FROM arm64v8/php:7.4-fpm-alpine
 
-ENV COMPOSER_VERSION 1.9.1
+ENV COMPOSER_VERSION 2.0.12
 ENV WP_CLI_VERSION 2.4.0
 
 RUN apk add --no-cache --virtual .build-deps \

--- a/7.4/xdebug/Dockerfile
+++ b/7.4/xdebug/Dockerfile
@@ -1,6 +1,6 @@
-FROM pilothouseapp/php:7.4-dev
+FROM pilothouse_php74:latest
 
 RUN apk add --no-cache --virtual .build-deps \
 	autoconf g++ make \
-	&& pecl install xdebug-2.9.1 && docker-php-ext-enable xdebug \
+	&& pecl install xdebug-3.0.3 && docker-php-ext-enable xdebug \
 	&& apk del .build-deps

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
 PHP Docker images for [Pilothouse App](https://github.com/Pilothouse-App/pilothouse)
 
 Dockerfiles in the `master` branch here are used in the Pilothouse `master` branch, and `develop` branches here are used in the Pilothouse `develop` branch.
+
+Apple Sillicon users can use `apple-sillicon` branch to have ARM64 images.
+

--- a/README.md
+++ b/README.md
@@ -2,5 +2,5 @@ PHP Docker images for [Pilothouse App](https://github.com/Pilothouse-App/pilotho
 
 Dockerfiles in the `master` branch here are used in the Pilothouse `master` branch, and `develop` branches here are used in the Pilothouse `develop` branch.
 
-Apple Sillicon users can use `apple-sillicon` branch to have ARM64 images.
+Apple Silicon users can use `apple-silicon` branch to have ARM64 images.
 


### PR DESCRIPTION
Hello, 

I made some adjustment to update Composer version and to use ARM64 images. I have a new Apple M1 computer and Docker works better with ARM64 images so it doesn't uses any emulation for x86 images. This branch only does that. I'm wondering if it can be added to the project.

